### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ conda create --name patchsae python=3.12
 conda activate patchsae
 
 # Install dependencies
-pip install -r requirements.txt
-
-# Always set PYTHONPATH before running any scripts
 cd patchsae
+pip install -r requirements.txt
+```
+
+When running any scripts, make sure to always set the `PYTHONPATH`. For example, to run the demo in `app.py`:
+
+```bash
 PYTHONPATH=./ python src/demo/app.py
 ```
 
@@ -60,7 +63,11 @@ First, download the necessary files:
 You can download the files using `gdown` as follows:
 
 ```bash
-# Activate environment first (see Getting Started)
+# Activate environment
+conda activate patchsae
+
+# Install gdown (if not installed yet)
+pip install gdown
 
 # Download necessary files (35MB + 513MB)
 gdown --id 1NJzF8PriKz_mopBY4l8_44R0FVi2uw2g  # out.zip

--- a/README.md
+++ b/README.md
@@ -62,12 +62,11 @@ First, download the necessary files:
 
 You can download the files using `gdown` as follows:
 
+> 💡 Need `gdown`? Install it with: `conda install conda-forge::gdown` or `pip install gdown`
+
 ```bash
 # Activate environment
 conda activate patchsae
-
-# Install gdown (if not installed yet)
-pip install gdown
 
 # Download necessary files (35MB + 513MB)
 gdown 1NJzF8PriKz_mopBY4l8_44R0FVi2uw2g  # out.zip
@@ -78,7 +77,6 @@ unzip data.zip
 unzip out.zip
 ```
 
-> 💡 Need `gdown`? Install it with: `conda install conda-forge::gdown`
 
 Your folder structure should look like:
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ conda activate patchsae
 pip install gdown
 
 # Download necessary files (35MB + 513MB)
-gdown --id 1NJzF8PriKz_mopBY4l8_44R0FVi2uw2g  # out.zip
-gdown --id 1reuDjXsiMkntf1JJPLC5a3CcWuJ6Ji3Z  # data.zip
+gdown 1NJzF8PriKz_mopBY4l8_44R0FVi2uw2g  # out.zip
+gdown 1reuDjXsiMkntf1JJPLC5a3CcWuJ6Ji3Z  # data.zip
 
 # Extract files
 unzip data.zip


### PR DESCRIPTION
This PR introduces minor updates to the README file to clarify some points that I found confusing when first using PatchSAE:

- Clarify that setting the `PYTHONPATH` is always required before running any script
- Updated the section about downloading files with gdown: the `--id` argument is deprecated and will raise an error in future gdown versions